### PR TITLE
add new pages and navigation to display more charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <table width='100%' cellspacing='0' cellpadding='0'><tr><td id='kasside' style='vertical-align:top;'><ul>
 <li class="hilight"><a accesskey="h" href="index.html">hash rate</a></li>
-<li>&nbsp;</li>
+<li><a accesskey="h" href="versions.html">block version</a></li>
 </ul></td>
 <td id='kasbody' style='vertical-align:top;'>
 Click on the graphs to see larger versions.
@@ -32,7 +32,7 @@ Exponential axis:<br/>
 </p>
 
 <p>
-<h3>Total cummulative number of hashes</h3>
+<h3>Total cumulative number of hashes</h3>
 <a href="work-ever.png"><img src="work-small-ever.png" /> </a>
 <a href="work.png"><img src="work-small.png" /> </a>
 </p>
@@ -44,7 +44,20 @@ Exponential axis:<br/>
 <a href="growth-10k.png"><img src="growth-small-10k.png" /> </a>
 </p>
 
+<h3>Proof of Work Equivalent Days</h3>
+
+<p>
+The ratio of total work divided by estimate of hashrate at that time.
+Thus it's the amount of time it would take for an attacker with 100% of the hashrate to rewrite the entire blockchain.</br>
+<a href="powdays-50k.png"><img src="powdays-small-50k.png" /> </a>
+<a href="powdays-ever.png"><img src="powdays-small-ever.png" /> </a>
+</p>
+
 </td></tr></table>
 
 <div id='kasfoot'>
-<a title="copyright (c) 2011-2016 by Pieter Wuille">Tips and donations: 1NrohbDoPkARCGdjvtnXbwFLwoBH86pskX</a></div></body></html>
+<a title="copyright (c) 2011-2016 by Pieter Wuille">Tips and donations: 1NrohbDoPkARCGdjvtnXbwFLwoBH86pskX</a><br/>
+<a href="https://github.com/sipa/bitcoin-stats">bitcoin-stats on GitHub</a>
+</div>
+</body>
+</html>

--- a/versions.html
+++ b/versions.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" >
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel='stylesheet' type="text/css" href='index.css' />
+<title>Bitcoin network graphs</title>
+</head>
+<body>
+<div id='kaslogo'><a href="http://www.bitcoin.org">Bitcoin <span style="font-size:11px">network graphs</span></a></div>
+<!-- <div id='kashead'>Logged in as someone <br/></div> -->
+
+<table width='100%' cellspacing='0' cellpadding='0'><tr><td id='kasside' style='vertical-align:top;'><ul>
+<li><a accesskey="h" href="index.html">hash rate</a></li>
+<li class="hilight"><a accesskey="h" href="versions.html">block version</a></li>
+</ul></td>
+<td id='kasbody' style='vertical-align:top;'>
+Click on the graphs to see larger versions.
+<h3>Block Versions</h3>
+
+<p>
+BIP9 Version Signaling:<br/>
+<a href="ver9-2k.png"><img src="ver9-small-2k.png" /> </a>
+<a href="ver9-10k.png"><img src="ver9-small-10k.png" /> </a>
+<a href="ver9-50k.png"><img src="ver9-small-50k.png" /> </a>
+<a href="ver9-ever.png"><img src="ver9-small-ever.png" /> </a>
+</p>
+
+<p>
+Historic Version Signaling:<br/>
+<a href="ver-2k.png"><img src="ver-small-2k.png" /> </a>
+<a href="ver-10k.png"><img src="ver-small-10k.png" /> </a>
+<a href="ver-50k.png"><img src="ver-small-50k.png" /> </a>
+<a href="ver-ever.png"><img src="ver-small-ever.png" /> </a>
+</p>
+
+</td></tr></table>
+
+<div id='kasfoot'>
+<a title="copyright (c) 2011-2016 by Pieter Wuille">Tips and donations: 1NrohbDoPkARCGdjvtnXbwFLwoBH86pskX</a><br/>
+<a href="https://github.com/sipa/bitcoin-stats">bitcoin-stats on GitHub</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adding a new "block version" page with both the BIP9 and historic block version signaling charts.

Adding "misc" page with the coin age chart; let me know if I missed any other random charts that should go here.

Also added the "PoW Equivalent Days" charts to the main hash rate page. I think that I have an idea what this statistic means, but can you explain it in detail? I think it should probably include an explanation on the site so that the average viewer isn't confused.

Finally, I added a link to the github so that others can contribute :smile: 